### PR TITLE
fix: improve `Toast` auto-dismiss logic in `DashBoard`

### DIFF
--- a/src/components/DashBoard/index.tsx
+++ b/src/components/DashBoard/index.tsx
@@ -70,8 +70,18 @@ const DashBoard: React.FC = () => {
   // 顯示 Toast 訊息
   const showToast = (msg: string) => {
     setToastMessage(msg);
-    setTimeout(() => setToastMessage(""), 3000);
   };
+
+  // 監聽 `toastMessage`，在設定後 2.5 秒自動清除
+  useEffect(() => {
+    if (toastMessage) {
+      const timeout = setTimeout(() => {
+        setToastMessage("");
+      }, 2500);
+
+      return () => clearTimeout(timeout); // 清除計時器，防止重複觸發
+    }
+  }, [toastMessage]);
 
   // 加入最愛
   const addToFavorites = (city: string, lat: number, lon: number) => {


### PR DESCRIPTION
- 改用 `useEffect` 監聽 `toastMessage`，在 2.5 秒後自動清除
- 移除原本的 `setTimeout`，改為 `clearTimeout` 避免重複觸發
- 提高 `Toast` 消息顯示的穩定性與可控性